### PR TITLE
Simple Image Metadata Command

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -74,11 +74,11 @@ Filename: {enumattach.Current.Filename}
 Width:    {enumattach.Current.Width}px
 Height:   {enumattach.Current.Height}px
 Size:     {(enumattach.Current.Size / (1024.0 * 1024)).ToString("0.#")}MB
-```", false, null, null, null, new MessageReference(refmsg.Id));
+```", false, null, null, null, new MessageReference(message.Id));
                 }
                 else
                 {
-                    message.Channel.SendMessageAsync("This message does not have any attachments!", false, null, null, null, new MessageReference(message.Id));
+                    message.Channel.SendMessageAsync("The message you referenced does not have any attachments!", false, null, null, null, new MessageReference(message.Id));
                 }
             }
 

--- a/Program.cs
+++ b/Program.cs
@@ -60,6 +60,27 @@ namespace Medea
             {
                 message.Channel.SendMessageAsync($@"Your account was created at {message.Author.CreatedAt.DateTime.Date}");
             }
+            else if ((command.Equals("meta") || command.Equals("metadata")) && message.Reference != null)
+            {
+                IMessage refmsg = message.Channel.GetMessageAsync(message.Reference.MessageId.Value).Result;
+                if (refmsg.Attachments.Count > 0)
+                {
+                    IEnumerator<Discord.IAttachment> enumattach = refmsg.Attachments.GetEnumerator();
+                    enumattach.MoveNext();
+                    message.Channel.SendMessageAsync(
+                        $@"Metadata for first attachment in the referenced message:
+```
+Filename: {enumattach.Current.Filename}
+Width:    {enumattach.Current.Width}px
+Height:   {enumattach.Current.Height}px
+Size:     {(enumattach.Current.Size / (1024.0 * 1024)).ToString("0.#")}MB
+```", false, null, null, null, new MessageReference(refmsg.Id));
+                }
+                else
+                {
+                    message.Channel.SendMessageAsync("This message does not have any attachments!", false, null, null, null, new MessageReference(message.Id));
+                }
+            }
 
             return Task.CompletedTask;
         }

--- a/Program.cs
+++ b/Program.cs
@@ -73,7 +73,7 @@ namespace Medea
 Filename: {enumattach.Current.Filename}
 Width:    {enumattach.Current.Width}px
 Height:   {enumattach.Current.Height}px
-Size:     {(enumattach.Current.Size / (1024.0 * 1024)).ToString("0.#")}MB
+Size:     {(enumattach.Current.Size / (1024.0 * 1024)).ToString("0.##")}MB
 ```", false, null, null, null, new MessageReference(message.Id));
                 }
                 else

--- a/Program.cs
+++ b/Program.cs
@@ -19,19 +19,12 @@ namespace Medea
             _client.MessageReceived += CommandHandler;
             _client.Log += Log;
 
-            //  You can assign your bot token to a string, and pass that in to connect.
-            //  This is, however, insecure, particularly if you plan to have your code hosted in a public repository.
             var token = File.ReadAllText("token.txt");
 
-            // Some alternative options would be to keep your token in an Environment Variable or a standalone file.
-            // var token = Environment.GetEnvironmentVariable("NameOfYourEnvironmentVariable");
-            // var token = File.ReadAllText("token.txt");
-            // var token = JsonConvert.DeserializeObject<AConfigurationClass>(File.ReadAllText("config.json")).Token;
 
             await _client.LoginAsync(TokenType.Bot, token);
             await _client.StartAsync();
 
-            // Block this task until the program is closed.
             await Task.Delay(-1);
         }
 
@@ -43,15 +36,13 @@ namespace Medea
 
         private Task CommandHandler(SocketMessage message)
         {
-            //variables
             string command = "";
             int lengthOfCommand = -1;
 
-            //filtering messages begin here
-            if (!message.Content.StartsWith('?')) //This is your prefix
+            if (!message.Content.StartsWith('?'))
                 return Task.CompletedTask;
 
-            if (message.Author.IsBot) //This ignores all commands from bots
+            if (message.Author.IsBot)
                 return Task.CompletedTask;
 
             if (message.Content.Contains(' '))
@@ -61,7 +52,6 @@ namespace Medea
 
             command = message.Content.Substring(1, lengthOfCommand - 1).ToLower();
 
-            //Commands begin here
             if (command.Equals("hello"))
             {
                 message.Channel.SendMessageAsync($@"Hello {message.Author.Mention}");


### PR DESCRIPTION
Simple command to view Discord's accessible metadata for the first attachments in a referenced message.

`?[metadata|meta]`, referencing a message with an attachment, will return the following metadata:
* Filename
* Width (px)
* Height (px)
* Size (MB, up to 2dp)